### PR TITLE
trim null chars when loading string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,12 @@ struct SecretFileFull {
 
 /// Load keys from the string contents of a js ssb secret file.
 pub fn keys_from_str(s: &str) -> Result<(PublicKey, SecretKey), Error> {
-    let sec_str = s
+    let raw_sec_str = s
         .lines()
         .filter(|s| !s.starts_with('#'))
         .collect::<Vec<&str>>()
         .concat();
+    let sec_str = raw_sec_str.trim_matches(char::from(0));
 
     // let v = serde_json::from_str::<serde_json::Value>(&sec_str)?;
     let sec = serde_json::from_str::<SecretFile>(&sec_str).context(Json)?;


### PR DESCRIPTION
I'm in the process of writing [ssb-neon-keys](https://github.com/staltz/ssb-neon-keys) which is a Rust implementation of a Node.js native module that aims to mirror as closely as possible the JS ssb-keys. While doing that, I'm finding a bunch of corner cases that need to be covered, and this PR addresses one of these.

One of the ssb-keys tests runs a simple `fs.writeFileSync` with JSON, and for some reason, this Rust library after doing these `filter` and `collect` operations will see (on the byte level) a bunch of `0` bytes (I think at least a hundred of these), and this makes Serde panic.

This PR just trims away these `0` characters, and helps tests pass in ssb-neon-keys.

PS: I hope you don't mind if I see a few more PRs? :) 