### PR TITLE
Update version number to reflect license change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-keyfile"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["AljoschaMeyer <mail@aljoscha-meyer.de>"]
 description = "Keyfile operations for ssb."
 repository = "https://github.com/sunrise-choir/ssb-keyfile-rs"
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.60"
-ssb-crypto = "0.2.2"
+ssb-crypto = "0.2.3"
 thiserror = "1.0.22"
 base64 = "0.13.0"
 structopt = { version = "0.3.21", optional = true }


### PR DESCRIPTION
Bumps `ssb-crypto` from `0.2.2` -> `0.2.3`

Crate version `0.5.3` -> `0.5.4`

Allows us to publish the latest version to crates.io.